### PR TITLE
Aprimora cálculo de estoque e datas

### DIFF
--- a/modules/estoque_veiculos.py
+++ b/modules/estoque_veiculos.py
@@ -121,8 +121,12 @@ def validar_renavam(renavam: Optional[str]) -> bool:
     pattern = re.compile(CONFIG_EXTRACAO["validadores"].get("renavam", r'^\d{9,11}$'))
     return bool(pattern.fullmatch(renavam))
 
-def classificar_tipo_nota(emitente_cnpj: Optional[str], destinatario_cnpj: Optional[str], 
-                         cnpj_empresa: Optional[str], cfop: Optional[str]) -> str:
+def classificar_tipo_nota(
+    emitente_cnpj: Optional[str],
+    destinatario_cnpj: Optional[str],
+    cnpj_empresa: Union[str, List[str], None],
+    cfop: Optional[str],
+) -> str:
     """Classifica a nota como entrada ou saída com base nos CNPJs e CFOP."""
     # Prioridade 1: Se CFOP começa com 1, 2 ou 3, ou é especificamente 1102 ou 2102, é entrada
     if cfop:
@@ -136,11 +140,15 @@ def classificar_tipo_nota(emitente_cnpj: Optional[str], destinatario_cnpj: Optio
     # Prioridade 2: Usar a lógica baseada em CNPJ
     emitente = normalizar_cnpj(emitente_cnpj)
     destinatario = normalizar_cnpj(destinatario_cnpj)
-    cnpj_empresa = normalizar_cnpj(cnpj_empresa)
-    
-    if destinatario == cnpj_empresa:
+
+    if isinstance(cnpj_empresa, (list, tuple, set)):
+        cnpjs_empresa = [normalizar_cnpj(c) for c in cnpj_empresa]
+    else:
+        cnpjs_empresa = [normalizar_cnpj(cnpj_empresa)]
+
+    if destinatario in cnpjs_empresa:
         return "Entrada"
-    elif emitente == cnpj_empresa:
+    elif emitente in cnpjs_empresa:
         return "Saída"
     else:
         # Se não for possível determinar pelo CNPJ, usar uma lógica padrão
@@ -182,23 +190,24 @@ def limpar_texto(texto: Optional[str]) -> str:
     texto = re.sub(r'\s+', ' ', texto)  # Remove espaços extras
     return texto
 
-def formatar_data(data_str: Optional[str]) -> Optional[str]:
-    """Formata a data para o padrão brasileiro."""
+def formatar_data(data_str: Optional[str]) -> Optional[datetime]:
+    """Converte strings de data em objetos ``datetime``.
+
+    Manter as datas como ``datetime`` evita conversões repetidas durante as
+    agregações mensais.
+    """
     if not data_str:
         return None
     try:
-        # Tenta diferentes formatos de data que podem aparecer em XMLs de NFe
-        for fmt in ['%Y-%m-%dT%H:%M:%S%z', '%Y-%m-%dT%H:%M:%S', '%Y-%m-%d']:
+        for fmt in ["%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"]:
             try:
-                # Remove a parte do fuso horário se existir
-                data_str_limpa = re.sub(r'[-+]\d{2}:\d{2}$', '', data_str)
-                data = datetime.strptime(data_str_limpa, fmt)
-                return data.strftime('%d/%m/%Y')
+                data_str_limpa = re.sub(r"[-+]\d{2}:\d{2}$", "", data_str)
+                return datetime.strptime(data_str_limpa, fmt)
             except ValueError:
                 continue
     except Exception as e:
-        log.warning(f"Erro ao formatar data '{data_str}': {e}")
-    return data_str
+        log.warning(f"Erro ao converter data '{data_str}': {e}")
+    return None
 
 def extrair_placa(texto_completo: str) -> Optional[str]:
     """Extrai a placa de veículo usando regex."""
@@ -301,17 +310,58 @@ def extrair_dados_xml(xml_path: str) -> List[Dict[str, Any]]:
         xpath_campos = CONFIG_EXTRACAO.get("xpath_campos", {})
         
         # Garantir campos do cabeçalho sempre preenchidos
+        data_emissao = formatar_data(
+            root.findtext(
+                xpath_campos.get('Data Emissão', './/nfe:ide/nfe:dhEmi'),
+                namespaces=ns,
+            )
+        )
+
         cabecalho = {
             'Número NF': num_nf,
-            'Emitente Nome': root.findtext(xpath_campos.get('Emitente Nome', './/nfe:emit/nfe:xNome'), namespaces=ns) or 'Não informado',
-            'Emitente CNPJ': normalizar_cnpj(root.findtext(xpath_campos.get('Emitente CNPJ', './/nfe:emit/nfe:CNPJ'), namespaces=ns)) or 'Não informado',
-            'Destinatario Nome': root.findtext(xpath_campos.get('Destinatario Nome', './/nfe:dest/nfe:xNome'), namespaces=ns) or 'Não informado',
-            'Destinatario CNPJ': normalizar_cnpj(root.findtext(xpath_campos.get('Destinatario CNPJ', './/nfe:dest/nfe:CNPJ'), namespaces=ns)),
-            'Destinatario CPF': normalizar_cnpj(root.findtext(xpath_campos.get('Destinatario CPF', './/nfe:dest/nfe:CPF'), namespaces=ns)),
-            'CFOP': root.findtext(xpath_campos.get('CFOP', './/nfe:det/nfe:prod/nfe:CFOP'), namespaces=ns),
-            'Data Emissão': formatar_data(root.findtext(xpath_campos.get('Data Emissão', './/nfe:ide/nfe:dhEmi'), namespaces=ns)),
-            'Valor Total': root.findtext(xpath_campos.get('Valor Total', './/nfe:total/nfe:ICMSTot/nfe:vNF'), namespaces=ns),
-            'Tipo NF': root.findtext(xpath_campos.get('tpNF', './/nfe:ide/nfe:tpNF'), namespaces=ns)
+            'Emitente Nome': root.findtext(
+                xpath_campos.get('Emitente Nome', './/nfe:emit/nfe:xNome'),
+                namespaces=ns,
+            )
+            or 'Não informado',
+            'Emitente CNPJ': normalizar_cnpj(
+                root.findtext(
+                    xpath_campos.get('Emitente CNPJ', './/nfe:emit/nfe:CNPJ'),
+                    namespaces=ns,
+                )
+            )
+            or 'Não informado',
+            'Destinatario Nome': root.findtext(
+                xpath_campos.get('Destinatario Nome', './/nfe:dest/nfe:xNome'),
+                namespaces=ns,
+            )
+            or 'Não informado',
+            'Destinatario CNPJ': normalizar_cnpj(
+                root.findtext(
+                    xpath_campos.get('Destinatario CNPJ', './/nfe:dest/nfe:CNPJ'),
+                    namespaces=ns,
+                )
+            ),
+            'Destinatario CPF': normalizar_cnpj(
+                root.findtext(
+                    xpath_campos.get('Destinatario CPF', './/nfe:dest/nfe:CPF'),
+                    namespaces=ns,
+                )
+            ),
+            'CFOP': root.findtext(
+                xpath_campos.get('CFOP', './/nfe:det/nfe:prod/nfe:CFOP'),
+                namespaces=ns,
+            ),
+            'Data Emissão': data_emissao,
+            'Mês Emissão': data_emissao.replace(day=1) if data_emissao else None,
+            'Valor Total': root.findtext(
+                xpath_campos.get('Valor Total', './/nfe:total/nfe:ICMSTot/nfe:vNF'),
+                namespaces=ns,
+            ),
+            'Tipo NF': root.findtext(
+                xpath_campos.get('tpNF', './/nfe:ide/nfe:tpNF'),
+                namespaces=ns,
+            ),
         }
 
         log.debug(f"Cabeçalho extraído: {cabecalho}")
@@ -435,7 +485,7 @@ def extrair_dados_xml(xml_path: str) -> List[Dict[str, Any]]:
         log.error(traceback.format_exc())
         return []
 
-def processar_xmls(xml_paths: List[str], cnpj_empresa: str) -> pd.DataFrame:
+def processar_xmls(xml_paths: List[str], cnpj_empresa: Union[str, List[str]]) -> pd.DataFrame:
     """Processa múltiplos arquivos XML e retorna um DataFrame consolidado."""
     todos_registros = []
     total_xmls = len(xml_paths)
@@ -488,13 +538,27 @@ def processar_xmls(xml_paths: List[str], cnpj_empresa: str) -> pd.DataFrame:
 
     # Classificação e ajustes finais
     log.info("Aplicando classificações e ajustes finais ao DataFrame")
-    df['Tipo Nota'] = df.apply(lambda row: classificar_tipo_nota(
-        row['Emitente CNPJ'], 
-        row['Destinatario CNPJ'], 
-        cnpj_empresa,
-        row.get('CFOP')  # Adicionar CFOP como parâmetro
-    ), axis=1)
+    if isinstance(cnpj_empresa, (list, tuple, set)):
+        cnpj_list = [normalizar_cnpj(c) for c in cnpj_empresa]
+        empresa_padrao = cnpj_list[0] if cnpj_list else None
+    else:
+        empresa_padrao = normalizar_cnpj(cnpj_empresa)
+
+    df['Empresa CNPJ'] = empresa_padrao
+
+    df['Tipo Nota'] = df.apply(
+        lambda row: classificar_tipo_nota(
+            row['Emitente CNPJ'],
+            row['Destinatario CNPJ'],
+            cnpj_empresa,
+            row.get('CFOP'),
+        ),
+        axis=1,
+    )
     df['Tipo Produto'] = df.apply(classificar_produto, axis=1)
+
+    if 'Data Emissão' in df.columns:
+        df['Mês Emissão'] = df['Data Emissão'].dt.to_period('M').dt.start_time
     
     ## Tratamento de tipos de dados conforme especificado no layout_colunas
     log.info("Aplicando conversões de tipo aos dados extraídos")
@@ -541,7 +605,7 @@ def processar_xmls(xml_paths: List[str], cnpj_empresa: str) -> pd.DataFrame:
     return df
 
 # Função para facilitar o processamento direto de um diretório
-def processar_diretorio(diretorio: str, cnpj_empresa: str, extensao: str = ".xml") -> pd.DataFrame:
+def processar_diretorio(diretorio: str, cnpj_empresa: Union[str, List[str]], extensao: str = ".xml") -> pd.DataFrame:
     """Processa todos os arquivos XML em um diretório."""
     if not os.path.isdir(diretorio):
         log.error(f"Diretório não encontrado: {diretorio}")


### PR DESCRIPTION
## Summary
- mantém datas como objetos `datetime`
- calcula `Mês Emissão` na extração
- permite múltiplos CNPJs para uma empresa
- registra CNPJ da empresa nos dados extraídos
- adiciona colunas de mês em `gerar_estoque_fiscal`
- resume mensalmente por empresa, incluindo veículos não vendidos

## Testing
- `python -m py_compile modules/estoque_veiculos.py`
- `python -m py_compile modules/transformadores_veiculos.py`


------
https://chatgpt.com/codex/tasks/task_e_6841c7df5e8483269aee44a83fea34a8