### PR TITLE
Aprimora classificação de notas e produtos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# Empresas-de-ve-culos
+# Empresas de Veículos
+
+Scripts para extração e processamento de notas fiscais de veículos.


### PR DESCRIPTION
## Summary
- prioriza o CNPJ para identificar notas de entrada e saída
- evita classificar itens de entrada sem dados de veículo como veículo
- remove código duplicado em `estoque_veiculos`

## Testing
- `python -m py_compile modules/estoque_veiculos.py modules/transformadores_veiculos.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c7df5e8483269aee44a83fea34a8