### PR TITLE
Fix note classification with CFOP precedence

### DIFF
--- a/tests/test_classificar_tipo_nota.py
+++ b/tests/test_classificar_tipo_nota.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+
+from modules.estoque_veiculos import classificar_tipo_nota
+
+CNPJ = "41492247000150"
+
+@pytest.mark.parametrize("cfop,expected",[
+    ("1102","Entrada"),
+    ("2102","Entrada"),
+    ("5102","Saída"),
+    ("6102","Saída"),
+    ("9999","Indefinido"),
+])
+def test_cfop_priority(cfop, expected):
+    assert classificar_tipo_nota(CNPJ, "00000000000000", CNPJ, cfop) == expected
+
+
+def test_cnpj_fallback_entrada():
+    assert classificar_tipo_nota("123", CNPJ, CNPJ, None) == "Entrada"
+
+
+def test_cnpj_fallback_saida():
+    assert classificar_tipo_nota(CNPJ, "123", CNPJ, None) == "Saída"
+
+
+def test_cnpj_fallback_indefinido():
+    assert classificar_tipo_nota("123", "456", CNPJ, None) == "Indefinido"


### PR DESCRIPTION
## Summary
- prioritize CFOP parsing for note type
- ensure CFOP normalization handles numeric forms
- add tests for `classificar_tipo_nota`

## Testing
- `python -m compileall -q modules/estoque_veiculos.py tests/test_classificar_tipo_nota.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684348f601148326afcf4b9f2490590b