### PR TITLE
Limit final dataframe columns

### DIFF
--- a/config/layout_colunas.json
+++ b/config/layout_colunas.json
@@ -5,12 +5,7 @@
   "Emitente Nome": {"tipo": "str", "ordem": 4},
   "Destinatário Nome": {"tipo": "str", "ordem": 5},
   "Destinatário CNPJ": {"tipo": "str", "ordem": 6},
-  "Destinatário CPF": {"tipo": "str", "ordem": 7},
-  "Chassi": {"tipo": "str", "ordem": 8},
-  "Placa": {"tipo": "str", "ordem": 9},
-  "Renavam": {"tipo": "str", "ordem": 10},
-  "KM": {"tipo": "int", "ordem": 11},
-  "Ano Modelo": {"tipo": "int", "ordem": 12},
-  "Ano Fabricação": {"tipo": "int", "ordem": 13},
-  "Cor": {"tipo": "str", "ordem": 14}
+  "Chassi": {"tipo": "str", "ordem": 7},
+  "Placa": {"tipo": "str", "ordem": 8},
+  "Renavam": {"tipo": "str", "ordem": 9}
 }

--- a/modules/estoque_veiculos.py
+++ b/modules/estoque_veiculos.py
@@ -584,18 +584,15 @@ def processar_xmls(xml_paths: List[str], cnpj_empresa: Union[str, List[str]]) ->
         except Exception as e:
             log.warning(f"Erro ao converter coluna {coluna} para tipo {tipo}: {e}")
     
-    # Ordenar colunas conforme definido no layout_colunas
+    # Manter apenas as colunas definidas no layout
     try:
-        cols_ordenadas = sorted(
+        cols_final = sorted(
             [col for col in df.columns if col in LAYOUT_COLUNAS],
             key=lambda x: LAYOUT_COLUNAS[x].get("ordem", 999)
         )
-        # Adicionar colunas que não estão no layout mas existem no DataFrame
-        outras_colunas = [col for col in df.columns if col not in LAYOUT_COLUNAS]
-        todas_colunas = cols_ordenadas + outras_colunas
-        df = df[todas_colunas]
+        df = df[cols_final]
     except Exception as e:
-        log.warning(f"Erro ao ordenar colunas: {e}")
+        log.warning(f"Erro ao selecionar colunas finais: {e}")
     
     # Estatísticas para validação
     veiculos = df[df['Tipo Produto'] == 'Veículo'].shape[0]


### PR DESCRIPTION
## Summary
- trim `layout_colunas.json` to the essential fields
- keep only layout columns in the dataframe returned by `processar_xmls`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887a285dfdc83268c7ce628db15f624