### PR TITLE
Add ICMS and XML key extraction

### DIFF
--- a/config/extracao_config.json
+++ b/config/extracao_config.json
@@ -8,6 +8,8 @@
     "Destinatario CNPJ": ".//nfe:dest/nfe:CNPJ",
     "Destinatario CPF": ".//nfe:dest/nfe:CPF",
     "Valor Total": ".//nfe:total/nfe:ICMSTot/nfe:vNF",
+    "ICMS": ".//nfe:imposto/nfe:ICMS//nfe:vICMS",
+    "CHAVE XML": ".//nfe:infNFe/@Id",
     "Produto": ".//nfe:det/nfe:prod/nfe:xProd",
     "tpNF": ".//nfe:ide/nfe:tpNF"
   },

--- a/config/layout_colunas.json
+++ b/config/layout_colunas.json
@@ -12,5 +12,7 @@
   "KM": {"tipo": "int", "ordem": 11},
   "Ano Modelo": {"tipo": "int", "ordem": 12},
   "Ano Fabricação": {"tipo": "int", "ordem": 13},
-  "Cor": {"tipo": "str", "ordem": 14}
+  "Cor": {"tipo": "str", "ordem": 14},
+  "ICMS": {"tipo": "float", "ordem": 15},
+  "CHAVE XML": {"tipo": "str", "ordem": 16}
 }

--- a/modules/estoque_veiculos.py
+++ b/modules/estoque_veiculos.py
@@ -321,8 +321,20 @@ def extrair_dados_xml(xml_path: str) -> List[Dict[str, Any]]:
             )
         )
 
+        # Chave da NFe
+        chave_xml = None
+        chave_xpath = xpath_campos.get('CHAVE XML', './/nfe:infNFe/@Id')
+        if '@' in chave_xpath:
+            elem_path, attr = chave_xpath.rsplit('/@', 1)
+            elem = root.find(elem_path, ns)
+            if elem is not None:
+                chave_xml = elem.attrib.get(attr)
+        else:
+            chave_xml = root.findtext(chave_xpath, namespaces=ns)
+
         cabecalho = {
             'Número NF': num_nf,
+            'CHAVE XML': chave_xml,
             'Emitente Nome': root.findtext(
                 xpath_campos.get('Emitente Nome', './/nfe:emit/nfe:xNome'),
                 namespaces=ns,
@@ -398,8 +410,18 @@ def extrair_dados_xml(xml_path: str) -> List[Dict[str, Any]]:
             produto_completo = f"{xProd} {infAdProd} {infos_gerais}".strip()
             
             dados['Produto'] = limpar_texto(xProd)
-            
+
             log.debug(f"Processando item {i}: {dados['Produto'][:50]}...")
+
+            # Valor do ICMS do item
+            try:
+                icms_text = item.findtext(
+                    xpath_campos.get('ICMS', './/nfe:imposto/nfe:ICMS//nfe:vICMS'),
+                    namespaces=ns,
+                )
+                dados['ICMS'] = float(icms_text) if icms_text is not None else None
+            except Exception as e:
+                log.warning(f"Erro ao processar ICMS do item: {e}")
 
             # Procurar diretamente campos de veículo na estrutura XML
             try:

--- a/tests/test_extrair_campos.py
+++ b/tests/test_extrair_campos.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import tempfile
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+
+from modules.estoque_veiculos import extrair_dados_xml
+
+def test_extrair_icms_e_chave(tmp_path):
+    xml_content = '''<?xml version="1.0" encoding="UTF-8"?>
+<NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+    <infNFe Id="NFe12345678901234567890123456789012345678901234" versao="4.00">
+        <ide>
+            <nNF>1</nNF>
+            <dhEmi>2023-01-01T12:00:00-03:00</dhEmi>
+            <tpNF>1</tpNF>
+        </ide>
+        <emit>
+            <CNPJ>12345678000199</CNPJ>
+            <xNome>Empresa Emitente</xNome>
+        </emit>
+        <dest>
+            <CNPJ>98765432000188</CNPJ>
+            <xNome>Empresa Dest</xNome>
+        </dest>
+        <total>
+            <ICMSTot>
+                <vNF>1000.00</vNF>
+            </ICMSTot>
+        </total>
+        <det nItem="1">
+            <prod>
+                <xProd>CARRO XYZ</xProd>
+                <CFOP>5102</CFOP>
+                <vProd>1000.00</vProd>
+            </prod>
+            <imposto>
+                <ICMS>
+                    <ICMS00>
+                        <vICMS>180.00</vICMS>
+                    </ICMS00>
+                </ICMS>
+            </imposto>
+        </det>
+    </infNFe>
+</NFe>'''
+    xml_file = tmp_path / "nota.xml"
+    xml_file.write_text(xml_content, encoding="utf-8")
+
+    registros = extrair_dados_xml(str(xml_file))
+    assert len(registros) == 1
+    registro = registros[0]
+    assert registro["ICMS"] == 180.00
+    assert registro["CHAVE XML"] == "NFe12345678901234567890123456789012345678901234"


### PR DESCRIPTION
## Summary
- capture ICMS and XML key from each nota fiscal
- expose ICMS/CHAVE XML in extraction layout
- support those columns in dataframe generation
- test XML extraction for new fields

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887a283e440832695e7da83715795e3