### PR TITLE
Handle note nature via natOp

### DIFF
--- a/config/extracao_config.json
+++ b/config/extracao_config.json
@@ -9,7 +9,7 @@
     "Destinatario CPF": ".//nfe:dest/nfe:CPF",
     "Valor Total": ".//nfe:total/nfe:ICMSTot/nfe:vNF",
     "Produto": ".//nfe:det/nfe:prod/nfe:xProd",
-    "tpNF": ".//nfe:ide/nfe:tpNF"
+    "Natureza Operacao": ".//nfe:ide/nfe:natOp"
   },
   "regex_extracao": {
   "Chassi": "(?:CHASSI|CHAS|CH)[\\s:;.-]*([A-HJ-NPR-Z0-9]{17})",

--- a/config/layout_colunas.json
+++ b/config/layout_colunas.json
@@ -12,5 +12,6 @@
   "KM": {"tipo": "int", "ordem": 11},
   "Ano Modelo": {"tipo": "int", "ordem": 12},
   "Ano Fabricação": {"tipo": "int", "ordem": 13},
-  "Cor": {"tipo": "str", "ordem": 14}
+  "Cor": {"tipo": "str", "ordem": 14},
+  "Natureza Operação": {"tipo": "str", "ordem": 15}
 }

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+# modules package

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,5 @@ pandas
 openpyxl
 lxml
 xlsxwriter
-logging
-matplotlib 
+matplotlib
 seaborn
-PyYAML


### PR DESCRIPTION
## Summary
- parse `Natureza Operacao` from `<natOp>`
- include new column in layout and fallback config
- use this field instead of the old `Tipo NF`
- drop unused format in Excel export
- remove `logging`/`PyYAML` from requirements
- apply layout formatting inside `processar_xmls`
- make `modules` a proper package

## Testing
- `pip install -r requirements.txt | tail -n 20`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887a28691408326a81ac4ac873b5095