### PR TITLE
Fix extraction naming and preserve XML key

### DIFF
--- a/config/extracao_config.json
+++ b/config/extracao_config.json
@@ -4,13 +4,14 @@
     "Data Emissão": ".//nfe:ide/nfe:dhEmi",
     "Emitente Nome": ".//nfe:emit/nfe:xNome",
     "Emitente CNPJ": ".//nfe:emit/nfe:CNPJ",
-    "Destinatario Nome": ".//nfe:dest/nfe:xNome",
-    "Destinatario CNPJ": ".//nfe:dest/nfe:CNPJ",
+    "Destinatário Nome": ".//nfe:dest/nfe:xNome",
+    "Destinatário CNPJ": ".//nfe:dest/nfe:CNPJ",
+    "Destinatário CPF": ".//nfe:dest/nfe:CPF",
     "Número NF": ".//nfe:ide/nfe:nNF",
     "ICMS": ".//nfe:imposto/nfe:ICMS//nfe:vICMS",
     "CHAVE XML": ".//nfe:infNFe/@Id",
     "Produto": ".//nfe:det/nfe:prod/nfe:xProd",
-    "Natureza Operacao": ".//nfe:ide/nfe:natOp"
+    "Natureza Operação": ".//nfe:ide/nfe:natOp"
   },
   "regex_extracao": {
     "Chassi": "(?:CHASSI|CHAS|CH)[\\s:;.-]*([A-HJ-NPR-Z0-9]{17})",

--- a/config/layout_colunas.json
+++ b/config/layout_colunas.json
@@ -1,5 +1,4 @@
 {
-
   "CFOP": {"tipo": "str", "ordem": 1},
   "Data Emissão": {"tipo": "date", "ordem": 2},
   "Valor Total": {"tipo": "float", "ordem": 3},
@@ -14,4 +13,6 @@
   "Ano Modelo": {"tipo": "int", "ordem": 12},
   "Ano Fabricação": {"tipo": "int", "ordem": 13},
   "Cor": {"tipo": "str", "ordem": 14},
-  "Natureza Operação": {"tipo": "str", "ordem": 15}
+  "Natureza Operação": {"tipo": "str", "ordem": 15},
+  "CHAVE XML": {"tipo": "str", "ordem": 16}
+}

--- a/modules/configurador_planilha.py
+++ b/modules/configurador_planilha.py
@@ -27,6 +27,7 @@ except Exception:
         "Ano Fabricação": {"tipo": "int", "ordem": 13},
         "Cor": {"tipo": "str", "ordem": 14},
         "Natureza Operação": {"tipo": "str", "ordem": 15},
+        "CHAVE XML": {"tipo": "str", "ordem": 16},
     }
 
 def configurar_planilha(df):

--- a/modules/estoque_veiculos.py
+++ b/modules/estoque_veiculos.py
@@ -36,12 +36,12 @@ except Exception as e:
             "Data Emissão": ".//nfe:ide/nfe:dhEmi",
             "Emitente Nome": ".//nfe:emit/nfe:xNome",
             "Emitente CNPJ": ".//nfe:emit/nfe:CNPJ",
-            "Destinatario Nome": ".//nfe:dest/nfe:xNome",
-            "Destinatario CNPJ": ".//nfe:dest/nfe:CNPJ",
-            "Destinatario CPF": ".//nfe:dest/nfe:CPF",
+            "Destinatário Nome": ".//nfe:dest/nfe:xNome",
+            "Destinatário CNPJ": ".//nfe:dest/nfe:CNPJ",
+            "Destinatário CPF": ".//nfe:dest/nfe:CPF",
             "Valor Total": ".//nfe:total/nfe:ICMSTot/nfe:vNF",
             "Produto": ".//nfe:det/nfe:prod/nfe:xProd",
-            "Natureza Operacao": ".//nfe:ide/nfe:natOp"
+            "Natureza Operação": ".//nfe:ide/nfe:natOp"
         },
         "regex_extracao": {
             "Chassi": r'(?:CHASSI|CHAS|CH)[\s:;.-]*([A-HJ-NPR-Z0-9]{17})',
@@ -67,7 +67,8 @@ except Exception as e:
         "Combustível": {"tipo": "str", "ordem": 16},
         "Potência": {"tipo": "float", "ordem": 17},
         "Modelo": {"tipo": "str", "ordem": 18},
-        "Natureza Operação": {"tipo": "str", "ordem": 19}
+        "Natureza Operação": {"tipo": "str", "ordem": 19},
+        "CHAVE XML": {"tipo": "str", "ordem": 20}
     }
 
 
@@ -320,12 +321,11 @@ def extrair_dados_xml(xml_path: str) -> List[Dict[str, Any]]:
         xpath_campos = CONFIG_EXTRACAO.get("xpath_campos", {})
         
         # Garantir campos do cabeçalho sempre preenchidos
-        data_emissao = formatar_data(
-            root.findtext(
-                xpath_campos.get('Data Emissão', './/nfe:ide/nfe:dhEmi'),
-                namespaces=ns,
-            )
+        data_emissao_text = (
+            root.findtext(xpath_campos.get('Data Emissão', './/nfe:ide/nfe:dhEmi'), namespaces=ns)
+            or root.findtext('.//nfe:ide/nfe:dEmi', namespaces=ns)
         )
+        data_emissao = formatar_data(data_emissao_text)
 
         cabecalho = {
             'Número NF': num_nf,
@@ -342,35 +342,38 @@ def extrair_dados_xml(xml_path: str) -> List[Dict[str, Any]]:
                 )
             )
             or 'Não informado',
-            'Destinatario Nome': root.findtext(
-                xpath_campos.get('Destinatario Nome', './/nfe:dest/nfe:xNome'),
+            'Destinatário Nome': root.findtext(
+                xpath_campos.get('Destinatário Nome', './/nfe:dest/nfe:xNome'),
                 namespaces=ns,
             )
             or 'Não informado',
-            'Destinatario CNPJ': normalizar_cnpj(
+            'Destinatário CNPJ': normalizar_cnpj(
                 root.findtext(
-                    xpath_campos.get('Destinatario CNPJ', './/nfe:dest/nfe:CNPJ'),
+                    xpath_campos.get('Destinatário CNPJ', './/nfe:dest/nfe:CNPJ'),
                     namespaces=ns,
                 )
             ),
-            'Destinatario CPF': normalizar_cnpj(
+            'Destinatário CPF': normalizar_cnpj(
                 root.findtext(
-                    xpath_campos.get('Destinatario CPF', './/nfe:dest/nfe:CPF'),
+                    xpath_campos.get('Destinatário CPF', './/nfe:dest/nfe:CPF'),
                     namespaces=ns,
                 )
             ),
-            'CFOP': root.findtext(
-                xpath_campos.get('CFOP', './/nfe:det/nfe:prod/nfe:CFOP'),
-                namespaces=ns,
+            'CFOP': (
+                root.findtext(
+                    xpath_campos.get('CFOP', './/nfe:det/nfe:prod/nfe:CFOP'),
+                    namespaces=ns,
+                )
+                or root.findtext('.//CFOP', namespaces=ns)
             ),
             'Data Emissão': data_emissao,
-            'Mês Emissão': data_emissao.replace(day=1) if data_emissao else None,
+            'Mês Emissão': data_emissao.strftime('%m/%Y') if data_emissao else None,
             'Valor Total': root.findtext(
                 xpath_campos.get('Valor Total', './/nfe:total/nfe:ICMSTot/nfe:vNF'),
                 namespaces=ns,
             ),
             'Natureza Operação': root.findtext(
-                xpath_campos.get('Natureza Operacao', './/nfe:ide/nfe:natOp'),
+                xpath_campos.get('Natureza Operação', './/nfe:ide/nfe:natOp'),
                 namespaces=ns,
             ),
         }
@@ -570,7 +573,7 @@ def processar_xmls(xml_paths: List[str], cnpj_empresa: Union[str, List[str]]) ->
     df['Tipo Nota'] = df.apply(
         lambda row: classificar_tipo_nota(
             row['Emitente CNPJ'],
-            row['Destinatario CNPJ'],
+            row['Destinatário CNPJ'],
             cnpj_empresa,
             row.get('CFOP'),
         ),
@@ -579,7 +582,9 @@ def processar_xmls(xml_paths: List[str], cnpj_empresa: Union[str, List[str]]) ->
     df['Tipo Produto'] = df.apply(classificar_produto, axis=1)
 
     if 'Data Emissão' in df.columns:
-        df['Mês Emissão'] = df['Data Emissão'].dt.to_period('M').dt.start_time
+        df['Mês Emissão'] = pd.to_datetime(
+            df['Data Emissão'], errors='coerce'
+        ).dt.strftime('%m/%Y')
    
     # Aplicar configuração de layout e tipagem
     df = configurar_planilha(df)

--- a/tests/test_processar_xmls.py
+++ b/tests/test_processar_xmls.py
@@ -14,7 +14,7 @@ def test_processar_xmls_uses_configurador(monkeypatch):
     def fake_extrair(_):
         return [{
             "Emitente CNPJ": "111",
-            "Destinatario CNPJ": "222",
+            "Destinatário CNPJ": "222",
             "CFOP": "1102",
             "Chassi": "ABCDEFGH123456789",
             "Data Emissão": pd.Timestamp("2023-01-01")


### PR DESCRIPTION
## Summary
- unify accented column names across the extraction config and code
- include `CHAVE XML` in the layout definition and keep it when reordering
- improve fallback layout in configurador_planilha
- extract CFOP and Data Emissão using fallbacks
- format `Mês Emissão` as `mm/aaaa`
- update tests for new column naming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d48154508326ad5590aab721d840