### PR TITLE
Rename conflicting Drive helper

### DIFF
--- a/utils/drive_utils.py
+++ b/utils/drive_utils.py
@@ -99,7 +99,7 @@ def baixar_xmls_da_pasta(service, pasta_id: str, destino: str) -> List[str]:
     return caminhos
 
 
-def baixar_xmls_empresa(
+def baixar_xmls_empresa_zip(
     service,
     pasta_principal_id: str,
     nome_empresa: str,


### PR DESCRIPTION
## Summary
- rename the zip-based helper in `drive_utils` to avoid name clash with the same function in `google_drive_utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688901f885848326a5ade76fdb0d6b4c