### PR TITLE
Rename conflicting Drive helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,11 @@ from modules.apuracao_fiscal import calcular_apuracao
 from utils.filtros_utils import obter_anos_meses_unicos, aplicar_filtro_periodo
 from utils.formatador_utils import formatar_moeda, formatar_percentual
 from utils.interface_utils import formatar_df_exibicao
-from utils.google_drive_utils import baixar_xmls_empresa
+from utils.google_drive_utils import (
+    criar_servico_drive,
+    baixar_xmls_empresa_zip,
+    ROOT_FOLDER_ID,
+)
 
 # Configuração da página
 st.set_page_config(
@@ -408,12 +412,19 @@ with upload_area:
         if st.button("📂 Buscar XMLs do Drive"):
             with st.spinner("Baixando arquivos do Google Drive..."):
                 with tempfile.TemporaryDirectory() as tmpdir:
-                    xml_paths, mensagens = baixar_xmls_empresa(
+                    caminho_chave = os.getenv("GOOGLE_SERVICE_KEY", "./Chave_Veiculos.json")
+                    pasta_principal_id = ROOT_FOLDER_ID
+
+                    service = criar_servico_drive(caminho_chave)
+                    xml_paths = baixar_xmls_empresa_zip(
+                        service,
+                        pasta_principal_id,
                         empresa_selecionada_nome,
-                        dest_dir=tmpdir,
+                        tmpdir,
                     )
-                    for msg in mensagens:
-                        st.info(msg)
+                    st.success(
+                        f"XMLs baixados e extraídos: {len(xml_paths)} arquivos encontrados."
+                    )
                     executar_pipeline(xml_paths, cnpj_empresa)
     else:
         uploaded_files = st.file_uploader(

--- a/utils/drive_utils.py
+++ b/utils/drive_utils.py
@@ -99,7 +99,7 @@ def baixar_xmls_da_pasta(service, pasta_id: str, destino: str) -> List[str]:
     return caminhos
 
 
-def baixar_xmls_empresa(
+def baixar_xmls_empresa_zip(
     service,
     pasta_principal_id: str,
     nome_empresa: str,

--- a/utils/google_drive_utils.py
+++ b/utils/google_drive_utils.py
@@ -265,3 +265,29 @@ def baixar_xmls_empresa(
 
     mensagens.append(f"{len(xml_paths)} XMLs extraídos do ZIP.")
     return xml_paths, mensagens
+
+
+# --------------------------------------------------------------
+# Funções de alto nível exportadas para uso no aplicativo
+# --------------------------------------------------------------
+from .drive_utils import (
+    criar_servico_drive as _criar_servico_drive,
+    baixar_xmls_empresa_zip as _baixar_xmls_empresa_zip,
+)
+
+
+def criar_servico_drive(caminho_chave: str):
+    """Wrapper para ``drive_utils.criar_servico_drive``."""
+
+    return _criar_servico_drive(caminho_chave)
+
+
+def baixar_xmls_empresa_zip(
+    service,
+    pasta_principal_id: str,
+    nome_empresa: str,
+    dest_dir: str,
+) -> List[str]:
+    """Wrapper para ``drive_utils.baixar_xmls_empresa_zip``."""
+
+    return _baixar_xmls_empresa_zip(service, pasta_principal_id, nome_empresa, dest_dir)


### PR DESCRIPTION
## Summary
- patch `google_drive_utils` to provide wrappers for the renamed Drive helpers
- update `app.py` to use the new `criar_servico_drive` and `baixar_xmls_empresa_zip`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688901f885848326a5ade76fdb0d6b4c