### PR TITLE
refactor: streamline dashboard with native components

### DIFF
--- a/painel.py
+++ b/painel.py
@@ -1,10 +1,21 @@
-import streamlit as st
-import pandas as pd
+"""Painel principal da aplicação Streamlit.
+
+Este módulo concentra a interface do dashboard e o fluxo de carregamento
+dos dados. Antes as ações de navegação e de processamento eram construídas
+com HTML estático, o que impedia callbacks e travava a página. A nova
+versão utiliza apenas componentes nativos do Streamlit e controla o estado
+por ``st.session_state``.
+"""
+
+import io
 import json
 import os
-import zipfile
 import tempfile
+import zipfile
 from pathlib import Path
+
+import pandas as pd
+import streamlit as st
 
 from modules.estoque_veiculos import processar_xmls
 from modules.configurador_planilha import configurar_planilha
@@ -20,14 +31,23 @@ from utils.formatador_utils import formatar_moeda
 from utils.interface_utils import formatar_df_exibicao
 
 
-def _init_session():
-    if "processado" not in st.session_state:
-        st.session_state.processado = False
-        st.session_state.df_configurado = pd.DataFrame()
-        st.session_state.df_estoque = pd.DataFrame()
-        st.session_state.df_alertas = pd.DataFrame()
-        st.session_state.df_resumo = pd.DataFrame()
-        st.session_state.kpis = {}
+def _init_session() -> None:
+    """Inicializa chaves do ``st.session_state`` com valores seguros."""
+    defaults = {
+        "processado": False,
+        "df_configurado": pd.DataFrame(),
+        "df_estoque": pd.DataFrame(),
+        "df_alertas": pd.DataFrame(),
+        "df_resumo": pd.DataFrame(),
+        "kpis": {},
+        "page": "Relatórios",
+        "xml_paths": [],
+        "cnpj_empresa": "",
+        "filtro_ano": None,
+        "filtro_mes": None,
+    }
+    for chave, valor in defaults.items():
+        st.session_state.setdefault(chave, valor)
 
 
 def _carregar_empresas():
@@ -44,8 +64,10 @@ def _processar_arquivos(xml_paths, cnpj_empresa):
 
 
 def _executar_pipeline(xml_paths, cnpj_empresa):
+    """Executa todas as etapas de transformação dos dados."""
     df_config = _processar_arquivos(xml_paths, cnpj_empresa)
     if df_config.empty:
+        st.session_state.processado = False
         st.warning("Nenhum dado processado.")
         return
 
@@ -86,106 +108,121 @@ def _upload_manual(files):
         return paths
 
 
+def _exportar_excel(df: pd.DataFrame) -> bytes:
+    """Gera um arquivo Excel em memória a partir do DataFrame informado."""
+    with io.BytesIO() as buffer:
+        with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+            df.to_excel(writer, index=False)
+        return buffer.getvalue()
+
+
+def render_topbar(logo: Path) -> None:
+    """Renderiza a barra superior com navegação."""
+    col_logo, col_nav = st.columns([3, 2])
+    with col_logo:
+        if logo.exists():
+            st.image(str(logo), width=60)
+        else:
+            st.write("Logo não encontrada")
+        st.markdown("**NETO CONTABILIDADE**\nVILECRDE")
+    with col_nav:
+        pagina = st.radio(
+            "Navegação",
+            ["Relatórios", "Mapa de Vendas"],
+            horizontal=True,
+            index=0 if st.session_state.page == "Relatórios" else 1,
+        )
+        st.session_state.page = pagina
+
+
 def main():
     st.set_page_config(page_title="Dashboard Neto Contabilidade", layout="wide")
     _init_session()
 
     LOGO = Path("config/logo.png")
 
-    st.markdown(
-        """
-        <style>
-            body {background-color:#233143; color:#ffffff; font-family:Montserrat, Arial, sans-serif;}
-            .top-bar {background-color:#1a2536; padding:10px 25px; display:flex; align-items:center; justify-content:space-between;}
-            .top-title{display:flex; flex-direction:column; margin-left:15px;}
-            .top-title h1{margin:0; font-size:32px; font-weight:700;}
-            .top-title span.neto{color:#ffffff;}
-            .top-title span.contab{color:#d1d5db;}
-            .sub-title{font-size:14px; color:#d1d5db; margin-top:-4px;}
-            .nav-menu{display:flex; align-items:center; gap:20px;}
-            .nav-menu a{color:#ffffff; text-decoration:none; font-size:16px;}
-            .nav-menu button{background-color:#1f2937; border:none; padding:6px 15px; border-radius:5px; color:#ffffff; cursor:pointer;}
-            .nav-menu button:hover{background-color:#374151;}
-            .hamburger{width:22px; height:2px; background:#ffffff; position:relative;}
-            .hamburger:before,.hamburger:after{content:""; position:absolute; left:0; width:22px; height:2px; background:#ffffff;}
-            .hamburger:before{top:-6px;} .hamburger:after{top:6px;}
-            .kpi-card{background-color:#1a2536; border-radius:8px; padding:20px; box-shadow:0 2px 4px rgba(0,0,0,0.3); color:#f1f1f1; text-align:center;}
-            .kpi-title{font-size:16px; color:#d1d5db;}
-            .kpi-value{font-size:28px; color:#ffd700; margin-top:5px;}
-            .sidebar-title{color:#ffd700; font-size:20px; margin-bottom:10px;}
-            .styled-table tbody tr:nth-child(even){background-color:#2f4159;}
-            .styled-table tbody tr:nth-child(odd){background-color:#233143;}
-            .alert-card{background-color:#1a2536; border-radius:8px; padding:20px; text-align:center; color:#f1f1f1;}
-            .alert-title{font-size:16px; color:#d1d5db; margin-bottom:10px;}
-            .alert-badge{display:inline-block; width:60px; height:60px; line-height:60px; border-radius:50%; background-color:#ffd700; color:#1a2536; font-size:24px; font-weight:bold;}
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
-
     empresas = _carregar_empresas()
     nomes_empresas = [v["nome"] for v in empresas.values()]
 
     with st.sidebar:
-        st.image(LOGO, width=100)
+        if LOGO.exists():
+            st.image(str(LOGO), width=100)
         empresa_nome = st.selectbox("Empresa", [""] + nomes_empresas)
-        if not empresa_nome:
-            st.info("Selecione a empresa para iniciar")
-            return
-        chave = next(k for k, v in empresas.items() if v["nome"] == empresa_nome)
-        cnpj_empresa = empresas[chave]["cnpj_emitentes"][0]
-        st.markdown(f"**CNPJ:** {cnpj_empresa}")
+        if empresa_nome:
+            chave = next(k for k, v in empresas.items() if v["nome"] == empresa_nome)
+            st.session_state.cnpj_empresa = empresas[chave]["cnpj_emitentes"][0]
+            st.markdown(f"**CNPJ:** {st.session_state.cnpj_empresa}")
 
-        modo = st.radio("Fonte dos XMLs", ["Google Drive", "Upload Manual"])
-        if modo == "Google Drive":
-            if st.button("Buscar XMLs do Drive"):
-                with st.spinner("Baixando XMLs do Drive..."):
-                    service = criar_servico_drive()
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        xmls = baixar_xmls_empresa_zip(service, ROOT_FOLDER_ID, empresa_nome, tmpdir)
-                        _executar_pipeline(xmls, cnpj_empresa)
+            modo = st.radio("Fonte dos XMLs", ["Google Drive", "Upload Manual"])
+            if modo == "Google Drive":
+                if st.button("Baixar XMLs do Drive"):
+                    with st.spinner("Baixando XMLs do Drive..."):
+                        service = criar_servico_drive()
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            xmls = baixar_xmls_empresa_zip(
+                                service, ROOT_FOLDER_ID, empresa_nome, tmpdir
+                            )
+                    st.session_state.xml_paths = xmls
+                    st.session_state.processado = False
+                    st.success(f"{len(xmls)} arquivos obtidos.")
+            else:
+                uploaded = st.file_uploader(
+                    "Envie XML ou ZIP", type=["xml", "zip"], accept_multiple_files=True
+                )
+                if uploaded and st.button("Carregar arquivos"):
+                    paths = _upload_manual(uploaded)
+                    st.session_state.xml_paths = paths
+                    st.session_state.processado = False
+                    st.success(f"{len(paths)} arquivos carregados.")
+
+            if st.session_state.processado and not st.session_state.df_estoque.empty:
+                anos, meses = obter_anos_meses_unicos(
+                    st.session_state.df_estoque, "Data Base"
+                )
+                st.session_state.filtro_ano = st.selectbox("Ano", anos)
+                st.session_state.filtro_mes = st.selectbox(
+                    "Mês",
+                    meses,
+                    format_func=lambda m: [
+                        "Jan",
+                        "Fev",
+                        "Mar",
+                        "Abr",
+                        "Mai",
+                        "Jun",
+                        "Jul",
+                        "Ago",
+                        "Set",
+                        "Out",
+                        "Nov",
+                        "Dez",
+                    ][m - 1],
+                )
         else:
-            uploaded = st.file_uploader("Envie XML ou ZIP", type=["xml", "zip"], accept_multiple_files=True)
-            if uploaded:
-                paths = _upload_manual(uploaded)
-                _executar_pipeline(paths, cnpj_empresa)
+            st.info("Selecione a empresa para iniciar")
 
-        if st.session_state.processado:
-            anos, meses = obter_anos_meses_unicos(st.session_state.df_estoque, "Data Base")
-            ano = st.selectbox("Ano", anos)
-            mes = st.selectbox("Mês", meses, format_func=lambda m: ["Jan","Fev","Mar","Abr","Mai","Jun","Jul","Ago","Set","Out","Nov","Dez"][m-1])
-            st.session_state.filtro_ano = ano
-            st.session_state.filtro_mes = mes
+    render_topbar(LOGO)
 
-    # Top bar
-    with st.container():
-        st.markdown(
-            """
-            <div class='top-bar'>
-                <div style='display:flex;align-items:center;'>
-            """,
-            unsafe_allow_html=True,
-        )
-        st.image(LOGO, width=60)
-        st.markdown(
-            """
-                <div class='top-title'>
-                    <h1><span class='neto'>NETO</span> <span class='contab'>CONTABILIDADE</span></h1>
-                    <div class='sub-title'>VILECRDE</div>
-                </div>
-            </div>
-            <div class='nav-menu'>
-                <a href='#'>MAPA DE VENDAS</a>
-                <button>Relatórios</button>
-                <div class='hamburger'></div>
-            </div>
-            </div>
-            """,
-            unsafe_allow_html=True,
-        )
+    if not empresa_nome:
+        st.stop()
 
     if not st.session_state.processado:
-        st.warning("Nenhum dado carregado. Importe os XMLs para visualizar o painel.")
+        st.info("Nenhum dado processado.")
+        if st.session_state.xml_paths:
+            if st.button("Carregar / Reprocessar XMLs"):
+                with st.spinner("Processando XMLs..."):
+                    _executar_pipeline(
+                        st.session_state.xml_paths, st.session_state.cnpj_empresa
+                    )
+                if st.session_state.processado:
+                    st.success("Dados carregados com sucesso.")
+        else:
+            st.warning("Carregue os arquivos na barra lateral.")
+        return
+
+    # Navegação entre páginas
+    if st.session_state.page == "Mapa de Vendas":
+        st.write("Mapa de Vendas em construção.")
         return
 
     df_filtrado = aplicar_filtro_periodo(
@@ -194,52 +231,61 @@ def main():
         st.session_state.get("filtro_ano"),
         st.session_state.get("filtro_mes"),
     )
+
+    if df_filtrado.empty:
+        st.warning("Não há dados para o período selecionado.")
+        return
+
     kpis = gerar_kpis(df_filtrado)
 
     c1, c2, c3 = st.columns(3)
-    with c1:
-        st.markdown(
-            f"<div class='kpi-card'><div class='kpi-title'>Total Vendido</div><div class='kpi-value'>{formatar_moeda(kpis['Total Vendido (R$)'])}</div></div>",
-            unsafe_allow_html=True,
-        )
-    with c2:
-        st.markdown(
-            f"<div class='kpi-card'><div class='kpi-title'>Lucro Total</div><div class='kpi-value'>{formatar_moeda(kpis['Lucro Total (R$)'])}</div></div>",
-            unsafe_allow_html=True,
-        )
-    with c3:
-        st.markdown(
-            f"<div class='kpi-card'><div class='kpi-title'>Estoque Atual (R$)</div><div class='kpi-value'>{formatar_moeda(kpis['Estoque Atual (R$)'])}</div></div>",
-            unsafe_allow_html=True,
-        )
+    c1.metric("Total Vendido", formatar_moeda(kpis.get("Total Vendido (R$)", 0)))
+    c2.metric("Lucro Total", formatar_moeda(kpis.get("Lucro Total (R$)", 0)))
+    c3.metric(
+        "Estoque Atual (R$)",
+        formatar_moeda(kpis.get("Estoque Atual (R$)", 0)),
+    )
 
-    vendas = st.session_state.df_configurado[st.session_state.df_configurado["Tipo Nota"] == "Saída"].copy()
-    vendas = aplicar_filtro_periodo(vendas, "Data Emissão", st.session_state.get("filtro_ano"), st.session_state.get("filtro_mes"))
-    vendas_tab = vendas[["Produto", "Valor Total"]].rename(columns={"Valor Total": "Valor (R$)"})
+    st.download_button(
+        "Exportar relatório de estoque",
+        data=_exportar_excel(df_filtrado),
+        file_name="relatorio_estoque.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+    vendas = st.session_state.df_configurado[
+        st.session_state.df_configurado["Tipo Nota"] == "Saída"
+    ].copy()
+    vendas = aplicar_filtro_periodo(
+        vendas, "Data Emissão", st.session_state.get("filtro_ano"), st.session_state.get("filtro_mes")
+    )
+    vendas_tab = vendas[["Produto", "Valor Total"]].rename(
+        columns={"Valor Total": "Valor (R$)"}
+    )
 
     estoque_parado = df_filtrado[df_filtrado["Situação"] == "Em Estoque"].copy()
-    if "Data Emissão_entrada" in estoque_parado.columns:
+    if "Data Emissão_entrada" in estoque_parado.columns and not estoque_parado.empty:
         estoque_parado["Estoque (dias)"] = (
-            pd.Timestamp.today() - pd.to_datetime(estoque_parado["Data Emissão_entrada"], errors="coerce")
+            pd.Timestamp.today()
+            - pd.to_datetime(estoque_parado["Data Emissão_entrada"], errors="coerce")
         ).dt.days
-    estoque_tab = estoque_parado[["Chassi_entrada", "Estoque (dias)"]].rename(columns={"Chassi_entrada": "Estoque"})
+    estoque_tab = estoque_parado[["Chassi_entrada", "Estoque (dias)"]].rename(
+        columns={"Chassi_entrada": "Estoque"}
+    )
 
     c_left, c_right = st.columns([2, 1])
     with c_left:
         t1, t2 = st.columns(2)
         with t1:
             st.markdown("### Produtos Vendidos")
-            st.table(vendas_tab.style.set_table_attributes('class="styled-table"'))
+            st.dataframe(formatar_df_exibicao(vendas_tab), use_container_width=True)
         with t2:
             st.markdown("### Estoque Parado")
-            st.table(estoque_tab.style.set_table_attributes('class="styled-table"'))
+            st.dataframe(formatar_df_exibicao(estoque_tab), use_container_width=True)
     with c_right:
         st.markdown("### Alertas Fiscais")
         num_alertas = len(st.session_state.df_alertas)
-        st.markdown(
-            f"<div class='alert-card'><div class='alert-title'>Alertas Fiscais</div><div class='alert-badge'>{num_alertas}</div></div>",
-            unsafe_allow_html=True,
-        )
+        st.write(f"Total de alertas: {num_alertas}")
         if not st.session_state.df_alertas.empty:
             desired = ["Estoque Parado", "DDV"]
             existing = [c for c in desired if c in st.session_state.df_alertas.columns]
@@ -248,7 +294,7 @@ def main():
                 if existing
                 else st.session_state.df_alertas
             )
-            st.table(tabela.style.set_table_attributes('class="styled-table"'))
+            st.dataframe(formatar_df_exibicao(tabela), use_container_width=True)
         else:
             st.write("Nenhum alerta fiscal encontrado.")
 


### PR DESCRIPTION
## Summary
- replace HTML navigation with Streamlit widgets and session state management
- add explicit processing flow and data export
- strengthen handling of empty data and filters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890dce2fb008326b497867775212c77