### PR TITLE
Process XMLs only from base directory

### DIFF
--- a/modules/estoque_veiculos.py
+++ b/modules/estoque_veiculos.py
@@ -689,17 +689,17 @@ def processar_diretorio(
     cnpj_empresa: Union[str, List[str]],
     extensao: str = ".xml",
 ) -> pd.DataFrame:
-    """Processa todos os arquivos XML em ``diretorio`` de forma recursiva."""
+    """Processa todos os arquivos XML em ``diretorio`` sem percorrer subpastas."""
     if not os.path.isdir(diretorio):
         log.error(f"Diretório não encontrado: {diretorio}")
         return pd.DataFrame()
 
-    xml_paths: List[str] = []
-    for root, _, files in os.walk(diretorio):
-        for f in files:
-            if f.lower().endswith(extensao.lower()):
-                xml_paths.append(os.path.join(root, f))
-    
+    xml_paths: List[str] = [
+        os.path.join(diretorio, f)
+        for f in os.listdir(diretorio)
+        if f.lower().endswith(extensao.lower())
+    ]
+
     if not xml_paths:
         log.warning(
             f"Nenhum arquivo {extensao} encontrado no diretório {diretorio}"
@@ -840,10 +840,11 @@ if __name__ == "__main__":
     if args.xml:
         xml_paths = args.xml
     elif args.dir:
-        for root, _, files in os.walk(args.dir):
-            for f in files:
-                if f.lower().endswith('.xml'):
-                    xml_paths.append(os.path.join(root, f))
+        xml_paths = [
+            os.path.join(args.dir, f)
+            for f in os.listdir(args.dir)
+            if f.lower().endswith('.xml')
+        ]
     
     if not xml_paths:
         log.error("Nenhum arquivo XML especificado. Use --dir ou --xml")

--- a/painel.py
+++ b/painel.py
@@ -78,8 +78,8 @@ def _upload_manual(files) -> list[str]:
                 with zipfile.ZipFile(dest, "r") as zf:
                     for name in zf.namelist():
                         if name.lower().endswith(".xml"):
-                            extracted = upload_dir / name
-                            extracted.parent.mkdir(parents=True, exist_ok=True)
+                            base = Path(name).name
+                            extracted = upload_dir / base
                             with open(extracted, "wb") as out_f:
                                 out_f.write(zf.read(name))
                             paths.append(str(extracted))

--- a/utils/drive_utils.py
+++ b/utils/drive_utils.py
@@ -123,6 +123,9 @@ def baixar_xmls_empresa_zip(
     with zipfile.ZipFile(zip_path, "r") as zf:
         for name in zf.namelist():
             if name.lower().endswith(".xml"):
-                zf.extract(name, destino)
-                xmls.append(os.path.join(destino, name))
+                base = os.path.basename(name)
+                caminho = os.path.join(destino, base)
+                with zf.open(name) as src, open(caminho, "wb") as out:
+                    out.write(src.read())
+                xmls.append(caminho)
     return xmls

--- a/utils/google_drive_utils.py
+++ b/utils/google_drive_utils.py
@@ -76,15 +76,13 @@ def _list_files(service, folder_id: str) -> List[dict]:
 
 
 def _download_files(service, folder_id: str, dest_dir: str) -> List[str]:
-    """Baixa recursivamente todos os arquivos XML da pasta para ``dest_dir``."""
+    """Baixa todos os arquivos XML da pasta para ``dest_dir`` (sem subpastas)."""
     os.makedirs(dest_dir, exist_ok=True)
     files = _list_files(service, folder_id)
     xml_paths: List[str] = []
     for f in files:
-        if f['mimeType'] == 'application/vnd.google-apps.folder':
-            # Descer em subpastas (ex: Entradas/2025/05-2025)
-            sub_dir = os.path.join(dest_dir, f['name'])
-            xml_paths.extend(_download_files(service, f['id'], sub_dir))
+        if f.get('mimeType') == 'application/vnd.google-apps.folder':
+            # Ignorar quaisquer pastas; XMLs devem estar diretamente na pasta raiz
             continue
         if not f['name'].lower().endswith('.xml'):
             continue


### PR DESCRIPTION
## Summary
- flatten extracted XMLs and skip subdirectories when downloading from Drive
- restrict XML scans to top-level files only

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891137568cc8326895bae56ad2a50a3