### PR TITLE
Improve XML pipeline validation and logging

### DIFF
--- a/modules/transformadores_veiculos.py
+++ b/modules/transformadores_veiculos.py
@@ -46,7 +46,13 @@ def gerar_estoque_fiscal(df_entrada, df_saida):
         merge_cols.append('Empresa CNPJ')
 
     # Remover duplicidades explícitas de saída para evitar múltiplas associações
+    antes = len(df_saida)
     df_saida = df_saida.drop_duplicates(subset=merge_cols)
+    removidas = antes - len(df_saida)
+    if removidas:
+        log.info(
+            f"Removidas {removidas} linhas duplicadas na saída com base em {merge_cols}"
+        )
 
     # Usar junção externa para identificar saídas sem entradas
     df_estoque = pd.merge(

--- a/tests/test_drive_utils.py
+++ b/tests/test_drive_utils.py
@@ -16,10 +16,10 @@ def test_baixar_xmls_empresa_zip(monkeypatch, tmp_path):
     def fake_baixar_arquivo(service, file_id, destino):
         assert file_id == "zip1"
         Path(destino).parent.mkdir(parents=True, exist_ok=True)
-        Path(destino).write_bytes(b"")
-        # Simula que o site extraiu o ZIP criando um XML na pasta destino
-        xml_path = Path(destino).parent / "nfe1.xml"
-        xml_path.write_text("<xml />", encoding="utf-8")
+        import zipfile
+
+        with zipfile.ZipFile(destino, "w") as zf:
+            zf.writestr("nfe1.xml", "<xml />")
     monkeypatch.setattr(du, "_buscar_subpasta_id", fake_buscar_subpasta_id)
     monkeypatch.setattr(du, "listar_arquivos", fake_listar_arquivos)
     monkeypatch.setattr(du, "baixar_arquivo", fake_baixar_arquivo)

--- a/tests/test_pipeline_persistencia.py
+++ b/tests/test_pipeline_persistencia.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import streamlit as st
+import painel
+
+
+def _df_exemplo():
+    return pd.DataFrame(
+        {
+            "Tipo Nota": ["Entrada", "Saída"],
+            "Chassi": ["ABC", "ABC"],
+            "Placa": ["AAA1234", "AAA1234"],
+            "CFOP": ["1102", "5102"],
+            "Valor Total": [100, 200],
+            "Data Emissão": ["2023-01-01", "2023-01-02"],
+            "Tipo Produto": ["Veículo", "Veículo"],
+            "Alerta Auditoria": ["", ""],
+            "Empresa CNPJ": ["123", "123"],
+            "ICMS Valor": [0, 0],
+        }
+    )
+
+
+def test_df_configurado_persistido(monkeypatch):
+    df = _df_exemplo()
+    monkeypatch.setattr(painel, "_processar_arquivos", lambda *args, **kwargs: df)
+    st.session_state.clear()
+    painel._init_session()
+    painel._executar_pipeline(["x.xml"], "123")
+    assert "df_configurado" in st.session_state
+    assert not st.session_state.df_configurado.empty

--- a/tests/test_validacao_campos.py
+++ b/tests/test_validacao_campos.py
@@ -1,0 +1,36 @@
+import pandas as pd
+import pytest
+from utils.validacao_utils import validar_campos_obrigatorios
+
+
+def _base_df():
+    return pd.DataFrame(
+        {
+            "Tipo Nota": ["Entrada"],
+            "Chassi": ["ABC"],
+            "Placa": ["AAA1234"],
+            "CFOP": ["5102"],
+            "Valor Total": [1000],
+            "Data Emissão": ["2023-01-01"],
+        }
+    )
+
+
+def test_validar_campos_obrigatorios_ok():
+    df = _base_df()
+    validar_campos_obrigatorios(df)  # não deve lançar
+
+
+def test_validar_campos_obrigatorios_coluna_ausente(caplog):
+    df = _base_df().drop(columns=["CFOP"])
+    with pytest.raises(ValueError):
+        validar_campos_obrigatorios(df)
+    assert "CFOP" in caplog.text
+
+
+def test_validar_campos_obrigatorios_valor_vazio(caplog):
+    df = _base_df()
+    df.loc[0, "Chassi"] = None
+    with pytest.raises(ValueError):
+        validar_campos_obrigatorios(df)
+    assert "Chassi" in caplog.text

--- a/utils/drive_utils.py
+++ b/utils/drive_utils.py
@@ -112,6 +112,15 @@ def baixar_xmls_empresa_zip(
     os.makedirs(destino, exist_ok=True)
     zip_path = os.path.join(destino, "empresa.zip")
     baixar_arquivo(service, alvo["id"], zip_path)
+    try:
+        import zipfile
+
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(destino)
+    except zipfile.BadZipFile as exc:
+        raise ValueError(
+            f"Arquivo ZIP inválido para a empresa '{nome_empresa}'"
+        ) from exc
 
     xmls = [
         os.path.join(destino, f)
@@ -119,5 +128,5 @@ def baixar_xmls_empresa_zip(
         if f.lower().endswith(".xml")
     ]
     if not xmls:
-        raise RuntimeError(f"Nenhum XML encontrado em {destino}")
+        raise FileNotFoundError(f"Nenhum XML encontrado em {destino}")
     return xmls

--- a/utils/validacao_utils.py
+++ b/utils/validacao_utils.py
@@ -1,0 +1,38 @@
+import logging
+import pandas as pd
+
+REQUIRED_COLUMNS = [
+    "Tipo Nota",
+    "Chassi",
+    "Placa",
+    "CFOP",
+    "Valor Total",
+    "Data Emissão",
+]
+
+log = logging.getLogger(__name__)
+
+def validar_campos_obrigatorios(df: pd.DataFrame) -> None:
+    """Verifica existência e preenchimento das colunas obrigatórias.
+
+    Lança ``ValueError`` se alguma coluna estiver ausente ou contiver valores
+    nulos/vazios. Mensagens detalhadas são registradas em log.
+    """
+    missing = [col for col in REQUIRED_COLUMNS if col not in df.columns]
+    if missing:
+        msg = f"Colunas obrigatórias ausentes: {', '.join(missing)}"
+        log.error(msg)
+        raise ValueError(msg)
+
+    vazio_cols = []
+    for col in REQUIRED_COLUMNS:
+        serie = df[col]
+        if serie.isna().any() or (serie.astype(str).str.strip() == "").any():
+            vazio_cols.append(col)
+    if vazio_cols:
+        msg = (
+            "Valores ausentes nas colunas obrigatórias: "
+            + ", ".join(vazio_cols)
+        )
+        log.error(msg)
+        raise ValueError(msg)


### PR DESCRIPTION
## Summary
- validate and log required DataFrame fields, store consolidated data in `st.session_state`
- add conversion and duplicate-removal logs with more specific exceptions and encoding-safe XML parsing
- add tests for mandatory field validation and session persistence
- extract and validate downloaded Drive archives before searching for XMLs

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689150f6755883269d74a53c994311df