### PR TITLE
Adiciona import de unicodedata em drive_utils

### DIFF
--- a/utils/drive_utils.py
+++ b/utils/drive_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import logging
 import zipfile
+import unicodedata
 from typing import List, Optional
 
 import json


### PR DESCRIPTION
## Summary
- add missing unicodedata import used for normalization in drive utils

## Testing
- `pytest -q` *(fails: NameError: name 'arquivos_zip' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6891ee4532c48326b6c9fd4a5c17aed6