### PR TITLE
Refatoração de extração de XMLs e desacoplamento de Streamlit

### DIFF
--- a/painel.py
+++ b/painel.py
@@ -103,10 +103,12 @@ def _upload_manual(files) -> list[str]:
 # Processamento de dados
 # ---------------------------------------------------------------------------
 
-def _processar_arquivos(xml_paths: list[str], cnpj_empresa: str) -> pd.DataFrame:
+def _processar_arquivos(
+    xml_paths: list[str], cnpj_empresa: str, erros: list[str] | None = None
+) -> pd.DataFrame:
     if not xml_paths:
         return pd.DataFrame()
-    df = processar_xmls(xml_paths, cnpj_empresa)
+    df = processar_xmls(xml_paths, cnpj_empresa, erros=erros)
     df = configurar_planilha(df)
     validar_campos_obrigatorios(df)
     return df
@@ -114,7 +116,9 @@ def _processar_arquivos(xml_paths: list[str], cnpj_empresa: str) -> pd.DataFrame
 
 def _executar_pipeline(xml_paths: list[str], cnpj_empresa: str) -> None:
     st.session_state["erros_xml"] = []
-    df_config = _processar_arquivos(xml_paths, cnpj_empresa)
+    df_config = _processar_arquivos(
+        xml_paths, cnpj_empresa, st.session_state["erros_xml"]
+    )
     st.session_state.df_configurado = df_config
     
     if df_config.empty:

--- a/tests/test_drive_utils.py
+++ b/tests/test_drive_utils.py
@@ -28,7 +28,7 @@ def test_baixar_xmls_empresa_zip(monkeypatch, tmp_path, caplog):
 
     with caplog.at_level(logging.INFO):
         xmls = du.baixar_xmls_empresa_zip(None, "root", "Empresa", tmp_path)
-    assert xmls == [str(tmp_path / "sub" / "nfe1.xml")]
+    assert xmls == [str(tmp_path / "qualquer" / "sub" / "nfe1.xml")]
     assert any("qualquer.zip" in r.message for r in caplog.records)
 
 
@@ -73,4 +73,4 @@ def test_multiplos_zips_com_config(monkeypatch, tmp_path):
     monkeypatch.setenv("NOME_ARQUIVO_ZIP", "b.zip")
 
     xmls = du.baixar_xmls_empresa_zip(None, "root", "Empresa", tmp_path)
-    assert xmls == [str(tmp_path / "nfe.xml")]
+    assert xmls == [str(tmp_path / "b" / "nfe.xml")]

--- a/tests/test_processar_xmls.py
+++ b/tests/test_processar_xmls.py
@@ -11,7 +11,7 @@ import modules.estoque_veiculos as ev
 def test_processar_xmls_uses_configurador(monkeypatch):
     called = {"called": False}
 
-    def fake_extrair(_):
+    def fake_extrair(_, erros=None):
         return [{
             "Emitente CNPJ/CPF": "111",
             "Destinatário CNPJ/CPF": "222",
@@ -29,7 +29,7 @@ def test_processar_xmls_uses_configurador(monkeypatch):
                 df[col] = None
         return df
 
-    monkeypatch.setattr(ev, "extrair_dados_xml", lambda path: fake_extrair(path))
+    monkeypatch.setattr(ev, "extrair_dados_xml", fake_extrair)
     monkeypatch.setattr(ev, "configurar_planilha", fake_config)
 
     df = ev.processar_xmls(["file.xml"], "111")


### PR DESCRIPTION
## Resumo
- Evita sobrescritas e ataques zip-slip ao baixar e extrair ZIPs do Google Drive
- Desacopla `extrair_dados_xml` de Streamlit permitindo coleta opcional de erros
- Atualiza pipeline do painel e testes para o novo fluxo de erros

## Testes
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68922f584de483268658974d32b769b9