### PR TITLE
Extract client and invoice info from XML for fiscal report

### DIFF
--- a/config/extracao_config.json
+++ b/config/extracao_config.json
@@ -12,7 +12,16 @@
     "ICMS": ".//nfe:imposto/nfe:ICMS//nfe:vICMS",
     "CHAVE XML": ".//nfe:infNFe/@Id",
     "Produto": ".//nfe:det/nfe:prod/nfe:xProd",
-    "Natureza Operação": ".//nfe:ide/nfe:natOp"
+    "Natureza Operação": ".//nfe:ide/nfe:natOp",
+    "CPF/CNPJ": ".//nfe:dest/nfe:CNPJ",
+    "Razão Social": ".//nfe:dest/nfe:xNome",
+    "UF": ".//nfe:dest/nfe:enderDest/nfe:UF",
+    "Município": ".//nfe:dest/nfe:enderDest/nfe:xMun",
+    "Endereço": ".//nfe:dest/nfe:enderDest/nfe:xLgr",
+    "Número Endereço": ".//nfe:dest/nfe:enderDest/nfe:nro",
+    "Número Documento": ".//nfe:ide/nfe:nNF",
+    "Série": ".//nfe:ide/nfe:serie",
+    "Data": ".//nfe:ide/nfe:dhEmi"
   },
   "regex_extracao": {
     "Chassi": "(?:CHASSI|CHAS|CH)[\\s:;.-]*([A-HJ-NPR-Z0-9]{17})",

--- a/modules/relatorio_fiscal_excel.py
+++ b/modules/relatorio_fiscal_excel.py
@@ -1,5 +1,9 @@
 import pandas as pd
 from typing import Dict, Optional
+import xml.etree.ElementTree as ET
+import re
+import os
+import json
 
 # Colunas finais do relatório
 COLUMNS = [
@@ -12,6 +16,109 @@ COLUMNS = [
     "Valor Unitário", "CST PIS/COFINS", "Base de Calculo PIS/COFINS",
     "Alíquota PIS", "Valor PIS", "Alíquota COFINS", "Valor COFINS",
 ]
+
+# Carregar configuração de extração de XML
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "config")
+try:
+    with open(os.path.join(CONFIG_PATH, "extracao_config.json"), encoding="utf-8") as f:
+        CONFIG_EXTRACAO = json.load(f)
+except Exception:
+    CONFIG_EXTRACAO = {"xpath_campos": {}}
+
+
+def _formatar_cnpj_cpf(valor: str) -> str:
+    """Formata CPF ou CNPJ adicionando máscaras padrão."""
+    if not valor:
+        return ""
+    digitos = re.sub(r"\D", "", valor)
+    if len(digitos) == 14:
+        return f"{digitos[:2]}.{digitos[2:5]}.{digitos[5:8]}/{digitos[8:12]}-{digitos[12:]}"
+    if len(digitos) == 11:
+        return f"{digitos[:3]}.{digitos[3:6]}.{digitos[6:9]}-{digitos[9:]}"
+    return valor
+
+
+def _extrair_dados_xml_basicos(xml_path: str) -> Dict[str, str]:
+    """Extrai campos básicos necessários para o relatório fiscal de um XML."""
+    try:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        ns_match = re.match(r"\{(.+?)\}", root.tag)
+        ns = {"nfe": ns_match.group(1)} if ns_match else {}
+
+        def tx(path: Optional[str]) -> str:
+            if not path:
+                return ""
+            return root.findtext(path, namespaces=ns) or ""
+
+        xpath_campos = CONFIG_EXTRACAO.get("xpath_campos", {})
+
+        cnpj = ""
+        for key in ("CPF/CNPJ", "Destinatário CNPJ", "Destinatário CPF"):
+            cnpj = tx(xpath_campos.get(key))
+            if cnpj:
+                break
+        if not cnpj:
+            cnpj = tx(".//nfe:dest/nfe:CNPJ") or tx(".//nfe:dest/nfe:CPF")
+
+        razao = (
+            tx(xpath_campos.get("Razão Social"))
+            or tx(xpath_campos.get("Destinatário Nome"))
+            or tx(".//nfe:dest/nfe:xNome")
+        )
+        uf = tx(xpath_campos.get("UF")) or tx(".//nfe:dest/nfe:enderDest/nfe:UF")
+        municipio = tx(xpath_campos.get("Município")) or tx(
+            ".//nfe:dest/nfe:enderDest/nfe:xMun"
+        )
+        logradouro = tx(xpath_campos.get("Endereço")) or tx(
+            ".//nfe:dest/nfe:enderDest/nfe:xLgr"
+        )
+        numero = tx(xpath_campos.get("Número Endereço")) or tx(
+            ".//nfe:dest/nfe:enderDest/nfe:nro"
+        )
+        endereco = " ".join(filter(None, [logradouro, numero])).strip()
+
+        numero_documento = (
+            tx(xpath_campos.get("Número Documento"))
+            or tx(xpath_campos.get("Número NF"))
+            or tx(".//nfe:ide/nfe:nNF")
+        )
+        serie = tx(xpath_campos.get("Série")) or tx(".//nfe:ide/nfe:serie")
+        data = (
+            tx(xpath_campos.get("Data"))
+            or tx(xpath_campos.get("Data Emissão"))
+            or tx(".//nfe:ide/nfe:dhEmi")
+            or tx(".//nfe:ide/nfe:dEmi")
+        )
+        if data:
+            try:
+                data = pd.to_datetime(data).date().isoformat()
+            except Exception:
+                pass
+        cfop = tx(xpath_campos.get("CFOP")) or tx(".//nfe:det/nfe:prod/nfe:CFOP")
+
+        return {
+            "CPF/CNPJ": _formatar_cnpj_cpf(cnpj),
+            "Razão Social": razao,
+            "UF": uf,
+            "Município": municipio,
+            "Endereço": endereco,
+            "Número Documento": numero_documento,
+            "Série": serie,
+            "Data": data,
+            "CFOP": cfop,
+        }
+    except Exception:
+        return {}
+
+
+def _resolver_xml_path(row: pd.Series) -> Optional[str]:
+    """Determina a coluna do caminho do XML disponível na linha."""
+    for col in ["XML Path", "XML Path_saida", "XML Path_entrada"]:
+        path = row.get(col)
+        if isinstance(path, str) and path:
+            return path
+    return None
 
 def gerar_relatorio_fiscal_excel(
     df_notas: pd.DataFrame,
@@ -37,6 +144,32 @@ def gerar_relatorio_fiscal_excel(
         DataFrame resultante com as colunas calculadas e ordenadas.
     """
     df = df_notas.copy()
+
+    # Tentar preencher campos essenciais a partir do XML, se ausentes
+    campos_xml = [
+        "CPF/CNPJ",
+        "Razão Social",
+        "UF",
+        "Município",
+        "Endereço",
+        "Número Documento",
+        "Série",
+        "Data",
+        "CFOP",
+    ]
+
+    for idx, row in df.iterrows():
+        if any(not row.get(c) for c in campos_xml):
+            xml_path = _resolver_xml_path(row)
+            if not xml_path:
+                continue
+            dados = _extrair_dados_xml_basicos(xml_path)
+            for campo in campos_xml:
+                valor_atual = row.get(campo)
+                if (campo not in df.columns) or (valor_atual in (None, "") or (isinstance(valor_atual, float) and pd.isna(valor_atual))):
+                    novo_valor = dados.get(campo)
+                    if novo_valor not in (None, ""):
+                        df.at[idx, campo] = novo_valor
 
     # Garantir que Valor Contábil corresponde ao Valor Produtos
     df["Valor Contábil"] = df["Valor Produtos"]

--- a/tests/test_relatorio_fiscal_excel.py
+++ b/tests/test_relatorio_fiscal_excel.py
@@ -1,4 +1,11 @@
+import os
+import sys
 import pandas as pd
+import json
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+
 from modules.relatorio_fiscal_excel import gerar_relatorio_fiscal_excel
 
 
@@ -35,3 +42,72 @@ def test_gerar_relatorio_fiscal_excel(tmp_path):
     assert result.loc[0, "Valor COFINS"] == 20000.0 * 0.03
     assert result.loc[0, "Acumulador"] == 3
     assert result.loc[0, "Código do Item"] == "COD123"
+
+
+def test_extracao_dados_basicos_xml(tmp_path):
+    xml_content = '''<?xml version="1.0" encoding="UTF-8"?>
+    <NFe xmlns="http://www.portalfiscal.inf.br/nfe">
+      <infNFe Id="NFe0001" versao="4.00">
+        <ide>
+          <nNF>1234</nNF>
+          <serie>1</serie>
+          <dhEmi>2024-01-01T00:00:00-03:00</dhEmi>
+        </ide>
+        <dest>
+          <CNPJ>99999999000101</CNPJ>
+          <xNome>Cliente Teste</xNome>
+          <enderDest>
+            <UF>SC</UF>
+            <xMun>Criciúma</xMun>
+            <xLgr>Rua Exemplo</xLgr>
+            <nro>1234</nro>
+          </enderDest>
+        </dest>
+        <det nItem="1">
+          <prod>
+            <CFOP>5101</CFOP>
+            <vProd>1000.00</vProd>
+          </prod>
+        </det>
+      </infNFe>
+    </NFe>'''
+
+    xml_file = tmp_path / "nota.xml"
+    xml_file.write_text(xml_content, encoding="utf-8")
+
+    df = pd.DataFrame({
+        "Valor Produtos": [1000.0],
+        "XML Path": [str(xml_file)],
+    })
+
+    saida = tmp_path / "relatorio.xlsx"
+    result = gerar_relatorio_fiscal_excel(df, saida)
+
+    row = result.iloc[0]
+    assert row["CPF/CNPJ"] == "99.999.999/0001-01"
+    assert row["Razão Social"] == "Cliente Teste"
+    assert row["UF"] == "SC"
+    assert row["Município"] == "Criciúma"
+    assert row["Endereço"] == "Rua Exemplo 1234"
+    assert row["Número Documento"] == "1234"
+    assert row["Série"] == "1"
+    assert row["Data"] == "2024-01-01"
+    assert row["CFOP"] == "5101"
+
+
+def test_config_contains_required_fields():
+    with open(os.path.join(ROOT, "config", "extracao_config.json"), encoding="utf-8") as f:
+        cfg = json.load(f)
+    campos = cfg.get("xpath_campos", {})
+    for campo in [
+        "CPF/CNPJ",
+        "Razão Social",
+        "UF",
+        "Município",
+        "Endereço",
+        "Número Documento",
+        "Série",
+        "Data",
+        "CFOP",
+    ]:
+        assert campo in campos, f"Campo {campo} ausente nas configurações"


### PR DESCRIPTION
## Summary
- expose XPath entries for CPF/CNPJ, Razão Social, UF, Município, Endereço, número e demais dados no `extracao_config.json`
- leverage the configurable XPath map in the fiscal report generator to fill missing client and invoice fields from XML
- add regression test ensuring XML configuration includes all required keys

## Testing
- `pytest tests/test_relatorio_fiscal_excel.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a521946c8326a55a8a7aa04fe353